### PR TITLE
Fix vote snapshot to proposal creation block

### DIFF
--- a/contracts/governance/DegenDAOInterfaces.sol
+++ b/contracts/governance/DegenDAOInterfaces.sol
@@ -145,6 +145,7 @@ contract DegenDAOStorageV1 is DegenDAOProxyStorage {
     struct Proposal {
         uint256 id;
         address proposer;
+        uint256 creationBlock;
         uint256 proposalThreshold;
         uint256 quorumVotes;
         uint256 eta;

--- a/contracts/governance/DegenDAOLogicV1.sol
+++ b/contracts/governance/DegenDAOLogicV1.sol
@@ -208,6 +208,7 @@ contract DegenDAOLogicV1 is DegenDAOStorageV1, DegenDAOEvents {
 
         newProposal.id = proposalCount;
         newProposal.proposer = msg.sender;
+        newProposal.creationBlock = block.number;
         newProposal.proposalThreshold = temp.proposalThreshold;
         newProposal.quorumVotes = bps2Uint(quorumVotesBPS, temp.totalSupply);
         newProposal.eta = 0;
@@ -494,7 +495,7 @@ contract DegenDAOLogicV1 is DegenDAOStorageV1, DegenDAOEvents {
         Receipt storage receipt = proposal.receipts[voter];
         require(receipt.hasVoted == false, 'DegenDAO::castVoteInternal: voter already voted');
 
-        uint96 votes = dogs.getPriorVotes(voter, proposal.startBlock - votingDelay);
+        uint96 votes = dogs.getPriorVotes(voter, proposal.creationBlock);
 
         if (support == 0) {
             proposal.againstVotes = proposal.againstVotes + votes;


### PR DESCRIPTION
This change fixes vote snapshotting to always use the proposal’s creation block. Previously the snapshot block was computed using the current votingDelay, so if votingDelay was changed after a proposal was created, vote power could be calculated at the wrong block. Now each proposal stores creationBlock and voting uses that fixed block for consistent results.

Changes:
Add creationBlock to Proposal storage
Set it in propose()
Use it in castVoteInternal() for getPriorVotes
Note:

Storage layout change (new field added)