### PR TITLE
fix/poolstreamer2-withdraw-underlying

### DIFF
--- a/contracts/PoolStreamer2.sol
+++ b/contracts/PoolStreamer2.sol
@@ -256,7 +256,7 @@ contract PoolStreamer2 is AccessControl {
         // downgrade amount from super token to underlying token
         _superToken(pool).downgrade(amount);
         // transfer amount to msg.sender
-        _superToken(pool).transfer(msg.sender, amount);
+        _underlyingToken(pool).transfer(msg.sender, amount);
     }
 
     function superToken(ISuperFluidPool pool) external view returns (address) {


### PR DESCRIPTION
withdrawAll in PoolStreamer2.sol downgrades super tokens to underlying, but then transfers the super token instead of the underlying token. This leaves funds stuck in the contract. Update the transfer to use the underlying token (and optionally use SafeERC20 for return checks).